### PR TITLE
dispose of cairo image surfaces and contexts

### DIFF
--- a/ApacheTech.VintageMods.CampaignCartographer/Features/ManualWaypoints/Dialogue/PredefinedWaypoints/PredefinedWaypointsGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/ManualWaypoints/Dialogue/PredefinedWaypoints/PredefinedWaypointsGuiCell.cs
@@ -56,6 +56,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.ManualWaypoints.D
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void PaintIcon(Context context, double x, double y, double squareSize)
@@ -120,6 +122,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.ManualWaypoints.D
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/ManualWaypoints/Dialogue/PredefinedWaypoints/PredefinedWaypointsGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/ManualWaypoints/Dialogue/PredefinedWaypoints/PredefinedWaypointsGuiCell.cs
@@ -56,8 +56,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.ManualWaypoints.D
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void PaintIcon(Context context, double x, double y, double squareSize)
@@ -122,14 +120,12 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.ManualWaypoints.D
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)
         {
-            var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
-            var context = genContext(imageSurface);
+            using var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
+            using var context = genContext(imageSurface);
             var num = scaled(UnscaledRightBoxWidth);
             if (left)
             {
@@ -152,8 +148,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.ManualWaypoints.D
             context.SetSourceRGBA(0.0, 0.0, 0.0, 0.15);
             context.Fill();
             generateTexture(imageSurface, ref textureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         public void OnRenderInteractiveElements(ICoreClientAPI capi, float deltaTime)

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
@@ -135,17 +135,14 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.PlayerPins.Patche
             var rgba = colour.Normalise();
             var outline = new[] { 0d, 0d, 0d, rgba[3] };
 
-            imageSurface = new ImageSurface(Format.Argb32, scale, scale);
-            context = new Context(imageSurface);
+            using var imageSurface = new ImageSurface(Format.Argb32, scale, scale);
+            using var context = new Context(imageSurface);
 
             context.SetSourceRGBA(0.0, 0.0, 0.0, 0.0);
             context.Paint();
             _capi.Gui.Icons.DrawMapPlayer(context, 0, 0, scale, scale, outline, rgba);
 
             var texture = _capi.Gui.LoadCairoTexture(imageSurface, false);
-
-            context.Dispose();
-            imageSurface.Dispose();
 
             return new LoadedTexture(_capi, texture, scale, scale);
         }

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
@@ -135,17 +135,17 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.PlayerPins.Patche
             var rgba = colour.Normalise();
             var outline = new[] { 0d, 0d, 0d, rgba[3] };
 
-            surface = new ImageSurface(Format.Argb32, scale, scale);
-            context = new Context(surface);
+            imageSurface = new ImageSurface(Format.Argb32, scale, scale);
+            context = new Context(imageSurface);
 
             context.SetSourceRGBA(0.0, 0.0, 0.0, 0.0);
             context.Paint();
             _capi.Gui.Icons.DrawMapPlayer(context, 0, 0, scale, scale, outline, rgba);
 
-            var texture = _capi.Gui.LoadCairoTexture(surface, false);
+            var texture = _capi.Gui.LoadCairoTexture(imageSurface, false);
 
             context.Dispose();
-            surface.Dispose();
+            imageSurface.Dispose();
 
             return new LoadedTexture(_capi, texture, scale, scale);
         }

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/PlayerPins/Patches/PlayerMapLayerPatches.cs
@@ -26,9 +26,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.PlayerPins.Patche
         private static IDictionary<IPlayer, EntityMapComponent> PlayerPins { get; set; }
         private static Dictionary<string, LoadedTexture> PlayerPinTextures { get; set; }
 
-        private static ImageSurface _imageSurface;
-        private static Context _context;
-
         [HarmonyPostfix]
         [HarmonyPatch(typeof(PlayerMapLayer), MethodType.Constructor, typeof(ICoreAPI), typeof(IWorldMapManager))]
         public static void Patch_PlayerMapLayer_Constructor_Postfix(ICoreAPI api, IWorldMapManager mapsink)
@@ -138,14 +135,18 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.PlayerPins.Patche
             var rgba = colour.Normalise();
             var outline = new[] { 0d, 0d, 0d, rgba[3] };
 
-            _imageSurface = new ImageSurface(Format.Argb32, scale, scale);
-            _context = new Context(_imageSurface);
+            surface = new ImageSurface(Format.Argb32, scale, scale);
+            context = new Context(surface);
 
-            _context.SetSourceRGBA(0.0, 0.0, 0.0, 0.0);
-            _context.Paint();
-            _capi.Gui.Icons.DrawMapPlayer(_context, 0, 0, scale, scale, outline, rgba);
+            context.SetSourceRGBA(0.0, 0.0, 0.0, 0.0);
+            context.Paint();
+            _capi.Gui.Icons.DrawMapPlayer(context, 0, 0, scale, scale, outline, rgba);
 
-            var texture = _capi.Gui.LoadCairoTexture(_imageSurface, false);
+            var texture = _capi.Gui.LoadCairoTexture(surface, false);
+
+            context.Dispose();
+            surface.Dispose();
+
             return new LoadedTexture(_capi, texture, scale, scale);
         }
 
@@ -155,8 +156,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.PlayerPins.Patche
         {
             PlayerPins.Purge();
             PlayerPinTextures.Purge();
-            _context.Dispose();
-            _imageSurface.Dispose();
             return true;
         }
     }

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Exports/WaypointExportGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Exports/WaypointExportGuiCell.cs
@@ -55,6 +55,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void PaintIcon(Context context, double x, double y, double squareSize)
@@ -118,6 +120,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Exports/WaypointExportGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Exports/WaypointExportGuiCell.cs
@@ -55,8 +55,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void PaintIcon(Context context, double x, double y, double squareSize)
@@ -120,14 +118,12 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)
         {
-            var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
-            var context = genContext(imageSurface);
+            using var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
+            using var context = genContext(imageSurface);
             var num = scaled(UnscaledRightBoxWidth);
             if (left)
             {
@@ -150,8 +146,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.SetSourceRGBA(0.0, 0.0, 0.0, 0.15);
             context.Fill();
             generateTexture(imageSurface, ref textureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         public void OnRenderInteractiveElements(ICoreClientAPI capi, float deltaTime)

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Imports/WaypointImportGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Imports/WaypointImportGuiCell.cs
@@ -52,8 +52,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void Compose()
@@ -102,14 +100,12 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)
         {
-            var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
-            var context = genContext(imageSurface);
+            using var imageSurface = new ImageSurface(0, (int)Bounds.OuterWidth, (int)Bounds.OuterHeight);
+            using var context = genContext(imageSurface);
             var num = scaled(UnscaledRightBoxWidth);
             if (left)
             {
@@ -132,8 +128,6 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.SetSourceRGBA(0.0, 0.0, 0.0, 0.15);
             context.Fill();
             generateTexture(imageSurface, ref textureId);
-            context.Dispose();
-            imageSurface.Dispose();
         }
 
         public void OnRenderInteractiveElements(ICoreClientAPI capi, float deltaTime)

--- a/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Imports/WaypointImportGuiCell.cs
+++ b/ApacheTech.VintageMods.CampaignCartographer/Features/WaypointUtil/Dialogue/Imports/WaypointImportGuiCell.cs
@@ -52,6 +52,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             RoundRectangle(context, 0.0, 0.0, size, size, 2.0);
             fillWithPattern(api, context, waterTextureName);
             generateTexture(imageSurface, ref _switchOnTextureId);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void Compose()
@@ -100,6 +102,8 @@ namespace ApacheTech.VintageMods.CampaignCartographer.Features.WaypointUtil.Dial
             context.Fill();
             EmbossRoundRectangleElement(context, x, y, scaledSwitchSize, scaledSwitchSize, true, 1, 2);
             generateTexture(imageSurface, ref _cellTexture);
+            context.Dispose();
+            imageSurface.Dispose();
         }
 
         private void ComposeHover(bool left, ref int textureId)


### PR DESCRIPTION
Unfortunately c4ca2ac didn't fix issue #9. I wasn't able to get the VS dev environment working in Arch Linux so I couldn't compile and test these changes, but I think this should resolve the issue.

In `PlayerMapLayerPatches.cs` the `LoadTexture` method was getting called multiple times from `Patch_PlayerMapLayer_OnMapOpenedClient_Prefix`, which was causing the `_imageSurface` and `_context` class variables to get reassigned before `Patch_PlayerMapLayer_Dispose_Prefix` had a chance to dispose of them. From the API docs, it seems like `ICoreClientAPI.Gui.LoadCairoTexture` copies the surface to an OpenGL texture so I think it's safe to dispose of it after that call. But that needs to be tested.

The other 3 files I changed all had the same issue. The `ComposeHover` method properly disposed of the context and surface but the `GenerateEnabledTexture` and `Compose` methods were missing that.